### PR TITLE
Add new options and correct alignment on top panel

### DIFF
--- a/package/config/config.qml
+++ b/package/config/config.qml
@@ -246,17 +246,39 @@ ColumnLayout {
                 indicator.configuration.progressAnimationEnabled = !indicator.configuration.progressAnimationEnabled
             }
         }
-    }
 
-    LatteComponents.CheckBox {
-        Layout.maximumWidth: dialog.optionsWidth
-        text: i18n("Show indicators for applets")
-        checked: indicator.configuration.enabledForApplets
-        tooltip: i18n("Indicators are shown for applets")
-        visible: deprecatedPropertiesAreHidden
+        LatteComponents.CheckBox {
+            Layout.maximumWidth: dialog.optionsWidth
+            text: i18n("Show indicators for applets")
+            checked: indicator.configuration.enabledForApplets
+            tooltip: i18n("Indicators are shown for applets")
+            visible: deprecatedPropertiesAreHidden
 
-        onClicked: {
-            indicator.configuration.enabledForApplets = !indicator.configuration.enabledForApplets;
+            onClicked: {
+                indicator.configuration.enabledForApplets = !indicator.configuration.enabledForApplets;
+            }
+        }
+
+        LatteComponents.CheckBox {
+            Layout.maximumWidth: dialog.optionsWidth
+            text: i18n("Hide background progressbar margins")
+            checked: indicator.configuration.hideProgressMargins
+            tooltip: i18n("Don’t show margins around backdrop progressbar on the task button")
+
+            onClicked: {
+                indicator.configuration.hideProgressMargins = !indicator.configuration.hideProgressMargins
+            }
+        }
+
+        LatteComponents.CheckBox {
+            Layout.maximumWidth: dialog.optionsWidth
+            text: i18n("Maximize indicator line when progressbar is active")
+            checked: indicator.configuration.maximizeActiveLineOnProgress
+            tooltip: i18n("Show full-size active task indicator line, when the task button has actove backdrop progressbar")
+
+            onClicked: {
+                indicator.configuration.maximizeActiveLineOnProgress = !indicator.configuration.maximizeActiveLineOnProgress
+            }
         }
     }
 }

--- a/package/config/main.xml
+++ b/package/config/main.xml
@@ -11,6 +11,12 @@
     <entry name="enabledForApplets" type="Bool">
         <default>true</default>
     </entry>    
+    <entry name="hideProgressMargins" type="Bool">
+        <default>false</default>
+    </entry>
+    <entry name="maximizeActiveLineOnProgress" type="Bool">
+        <default>false</default>
+    </entry>
     <entry name="maxBackgroundOpacity" type="Double">
         <default>0.35</default>
     </entry>

--- a/package/ui/BackLayer.qml
+++ b/package/ui/BackLayer.qml
@@ -72,7 +72,7 @@ Item{
 
                 Rectangle {
                     anchors.fill: parent
-                    anchors.margins: 1
+                    anchors.margins: Number(!indicator.configuration.hideProgressMargins)
                     radius: backRect.radius
                     color: "red"
                 }
@@ -105,11 +105,16 @@ Item{
 
     Rectangle {
         id: activeLine
-        anchors.bottom: parent.bottom
+
+        anchors.top: plasmoid.location === PlasmaCore.Types.TopEdge ? parent.top : undefined
+        anchors.bottom: plasmoid.location !== PlasmaCore.Types.TopEdge ? parent.bottom : undefined
+
         anchors.horizontalCenter: parent.horizontalCenter
 
+        property bool maximizeLineOnProgress: indicator.configuration.maximizeActiveLineOnProgress && indicator.configuration.progressAnimationEnabled && rectangleItem.showProgress && indicator.progress>0
+
         width: {
-            if (root.backgroundOpacity > 0 || (isSecondStackedBackLayer && !indicator.isHovered)) {
+            if (root.backgroundOpacity > 0 || (isSecondStackedBackLayer && !indicator.isHovered) || maximizeLineOnProgress) {
                 return parent.width;
             }
 


### PR DESCRIPTION
-   Align active lines to top when panel is on top edge
-   Option to hide progress margins
-   Option to make active line full-width when progress is active

![Screenshot_20200824_130043](https://user-images.githubusercontent.com/37388187/91031885-db814e00-e609-11ea-9af3-95575ffd2528.png)